### PR TITLE
fix: mongodb replica set

### DIFF
--- a/apps/backend/docker-compose.yml
+++ b/apps/backend/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  mongodb:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    command: ['--replSet', 'rs0']
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'localhost:27017'}]}) }" | mongosh --port 27017 --quiet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,0 @@
-services:
-  mongodb:
-    image: mongo
-    restart: always
-    ports:
-      - 27017:27017


### PR DESCRIPTION
- move `docker-compose.yml`
- make the mongodb instance create a replica set (_A MongoDB replica set is a group of mongodb instances that maintain the same data set_) on start up

### reason
this is [required by prisma](https://www.prisma.io/docs/orm/overview/databases/mongodb#differences-to-consider) for certain operations because it uses mongodb transactions internally