### PR TITLE
feat: validate helper

### DIFF
--- a/apps/backend/lib/validate.ts
+++ b/apps/backend/lib/validate.ts
@@ -1,0 +1,12 @@
+import type { z } from 'zod'
+import { ValidationError } from './error'
+
+export const validate = <T>(value: unknown, schema: z.Schema<T>) => {
+  const { success, error, data } = schema.safeParse(value)
+
+  if (!success) {
+    throw new ValidationError(error)
+  }
+
+  return data
+}


### PR DESCRIPTION
closes #76

- create helper function for validation
- throws a `ValidationError` if the validation fails
- returns the data (with the correct type) if it succeeds