### PR TITLE
feat: endpoint handler

### DIFF
--- a/apps/backend/lib/handle.ts
+++ b/apps/backend/lib/handle.ts
@@ -1,0 +1,22 @@
+import type { NextFunction, Request, Response } from 'express'
+import { handleError } from './error'
+
+type Callback = ({
+  req,
+  res,
+  next,
+}: {
+  req: Request
+  res: Response
+  next: NextFunction
+}) => Promise<void> | void
+
+export const handle = (callback: Callback) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await callback({ req, res, next })
+    } catch (error) {
+      handleError({ error, res })
+    }
+  }
+}


### PR DESCRIPTION
closes #77 

- create a helper function for handling endpoints
- wraps the function in a try catch and uses `handleError` for all errors
- makes the parameters a bit nicer to use by using an object