### PR TITLE
feat: create Button

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "tailwind-merge": "^3.3.0",
     "typescript": "~5.8.3",

--- a/apps/frontend/src/components/Button.tsx
+++ b/apps/frontend/src/components/Button.tsx
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { ElementType } from 'react'
+import type { Polymorphic } from '../types'
+import { cn } from '../utils/classname'
+
+const variants = cva(
+  'flex items-center justify-center gap-3 text-base font-bold whitespace-nowrap rounded-full transition cursor-pointer disabled:bg-slate-600 disabled:text-slate-800 disabled:cursor-auto',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-slate-800 text-slate-50 hover:bg-slate-950',
+        blue: 'bg-blue text-slate-800 hover:bg-blue-darker',
+        green: 'bg-green text-slate-800 hover:bg-green-darker',
+        red: 'bg-red text-slate-50 hover:bg-red-darker',
+      },
+      size: {
+        md: 'py-3 px-8',
+        sm: 'py-2 px-6',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  },
+)
+
+export const Button = <Element extends ElementType = 'button'>({
+  as,
+  children,
+  variant,
+  size,
+  className,
+  ...rest
+}: Polymorphic<VariantProps<typeof variants>, Element>) => {
+  const Element = as || 'button'
+
+  return (
+    <Element className={cn(variants({ variant, size, className }))} {...rest}>
+      {children}
+    </Element>
+  )
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -10,11 +10,22 @@
 
   --color-red-lighter: #ff895c;
   --color-red: #ff500d;
-  --color-red-darker: #c23600;
+  --color-red-darker: #d63c00;
 
   --color-yellow: #ffd93b;
   --color-yellow-darker: #ffd00a;
 
   --color-green: #8de767;
-  --color-green-darker: #6dda3e;
+  --color-green-darker: #5dd629;
+}
+
+@layer base {
+  * {
+    @apply outline-offset-1 outline-blue;
+  }
+
+  *:focus,
+  *:focus-visible {
+    @apply outline-1;
+  }
 }

--- a/apps/frontend/src/types.ts
+++ b/apps/frontend/src/types.ts
@@ -1,2 +1,11 @@
+import type { ComponentPropsWithoutRef, ElementType } from 'react'
+
 export type Suit = 'heart' | 'diamond' | 'club' | 'spade'
 export type Face = 'jack' | 'queen' | 'king'
+
+type Merge<T, U> = Omit<T, keyof U> & U
+
+export type Polymorphic<Props, Element extends ElementType> = Merge<
+  ComponentPropsWithoutRef<Element>,
+  Props & { as?: Element }
+>

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.3.0",
         "typescript": "~5.8.3",
@@ -445,6 +446,8 @@
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 


### PR DESCRIPTION
closes #39 

- install [class-variance-authority](https://cva.style/docs)
  - package to easily create variants in a structured way
- update some colors to better fit the hover state but still work with the rest of the design
- update focus color
- create a `Polymorphic` type that lets you dynamically decide what type of element a component should be
  - lets the button either be rendered as a `button` or an `a` element
- create `Button` component with 4 variants and 3 sizes

https://github.com/user-attachments/assets/12f94b69-b235-4c1c-87f3-3ff863679e32