### PR TITLE
feat: create logo component

### DIFF
--- a/apps/frontend/src/components/Logo.tsx
+++ b/apps/frontend/src/components/Logo.tsx
@@ -1,0 +1,19 @@
+import { Suit } from './Suit'
+
+export const Logo = ({ text }: { text?: boolean }) => {
+  return (
+    <div className="w-34">
+      <div className="flex gap-1">
+        <Suit variant="heart" size="lg" face />
+        <Suit variant="spade" size="lg" face />
+        <Suit variant="club" size="lg" face />
+        <Suit variant="diamond" size="lg" face />
+      </div>
+      {text ? (
+        <h1 className="w-full text-4xl leading-8 font-black">
+          HIT ME <br /> MAYBE
+        </h1>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/Logo.tsx
+++ b/apps/frontend/src/components/Logo.tsx
@@ -2,18 +2,18 @@ import { Suit } from './Suit'
 
 export const Logo = ({ text }: { text?: boolean }) => {
   return (
-    <div className="w-34">
+    <div className="w-min">
       <div className="flex gap-1">
         <Suit variant="heart" size="lg" face />
         <Suit variant="spade" size="lg" face />
         <Suit variant="club" size="lg" face />
         <Suit variant="diamond" size="lg" face />
       </div>
-      {text ? (
-        <h1 className="w-full text-4xl leading-8 font-black">
+      {text && (
+        <span className="w-full text-4xl leading-8 font-black">
           HIT ME <br /> MAYBE
-        </h1>
-      ) : null}
+        </span>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
closes #44
Create logo with optional `text` as a `h1`-element in logo.

Without `text` (default)
![image](https://github.com/user-attachments/assets/cb0d6b3d-e895-4045-8b97-044a4e25cbd8)


With `text`
![image](https://github.com/user-attachments/assets/5c358590-3b96-4a14-94dc-9cf90b27a723)

Note: Could be bigger for a `mainMenu` page but that is for a discussion