### PR TITLE
feat: create `statistic` component

### DIFF
--- a/apps/frontend/src/components/Statistic.tsx
+++ b/apps/frontend/src/components/Statistic.tsx
@@ -1,0 +1,16 @@
+import { Illustration } from './Illustration'
+
+export const Statistic = ({
+  illustration,
+  value,
+}: {
+  illustration: 'fire' | 'crown' | 'cloud'
+  value: string
+}) => {
+  return (
+    <div className="flex gap-1">
+      <Illustration variant={illustration} />
+      <span>{value}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #42 

Create a statistic component using `illustration` component.
Uses props for the `illustration` and the value that is of type `string`.
![image](https://github.com/user-attachments/assets/34049d2f-cc57-4a3e-897e-7712de60dcd1)