### PR TITLE
refactor: `validate` return

### DIFF
--- a/apps/backend/controllers/auth.ts
+++ b/apps/backend/controllers/auth.ts
@@ -102,7 +102,16 @@ const tokenResponse = async ({ id, res }: { id: string; res: Response }) => {
 }
 
 const refreshToken = handle(async ({ req, res }) => {
-  const refreshToken = validate(req.cookies['refresh-token'], z.string())
+  const refreshToken = validate(
+    req.cookies['refresh-token'],
+    z.string(),
+    'return',
+  )
+
+  if (!refreshToken) {
+    throw new AuthError('refresh token missing', 401)
+  }
+
   const tokenHash = hashToken(refreshToken)
 
   if (

--- a/apps/backend/lib/authenticate.ts
+++ b/apps/backend/lib/authenticate.ts
@@ -6,7 +6,7 @@ import { AuthError } from './error'
 import { validate } from './validate'
 
 export const authenticate = async (cookies: Request['cookies']) => {
-  const accessToken = validate(cookies['access-token'], z.string())
+  const accessToken = validate(cookies['access-token'], z.string(), 'return')
 
   if (!accessToken) {
     throw new AuthError('access token missing', 401)

--- a/apps/backend/lib/validate.ts
+++ b/apps/backend/lib/validate.ts
@@ -1,11 +1,33 @@
 import type { z } from 'zod'
 import { ValidationError } from './error'
 
-export const validate = <T>(value: unknown, schema: z.Schema<T>) => {
+// function overloads for proper return typing
+export function validate<Data>(
+  value: unknown,
+  schema: z.Schema<Data>,
+  behaviour?: 'throw',
+): Data
+export function validate<Data>(
+  value: unknown,
+  schema: z.Schema<Data>,
+  behaviour?: 'return',
+): Data | null
+
+export function validate<Data>(
+  value: unknown,
+  schema: z.Schema<Data>,
+  behaviour: 'throw' | 'return' = 'throw',
+) {
   const { success, error, data } = schema.safeParse(value)
 
   if (!success) {
-    throw new ValidationError(error)
+    if (behaviour === 'throw') {
+      throw new ValidationError(error)
+    }
+
+    if (behaviour === 'return') {
+      return null
+    }
   }
 
   return data


### PR DESCRIPTION
- refactor `validate` to optionally return null if there's an error instead of throwing a `ValidationError`
- use [function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to ensure the return is typed according to the `behavior`
- use the new `behavior` parameter in `authenticate` and `refreshToken` to return more useful errors

### reason
when the user wasn't authenticated you got a very not useful message saying:
```json
{
  "message": {
    "_errors": [
      "Required"
    ]
  }
}
```

now it says this instead:
```json
{
  "message": "access token missing"
}
```