### PR TITLE
feat: statistics endpoint

### DIFF
--- a/apps/backend/api/routes.ts
+++ b/apps/backend/api/routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { auth as authController } from '../controllers/auth'
+import { statistics as statisticsController } from '../controllers/statistics'
 import { user } from '../controllers/user'
 
 const auth = Router()
@@ -18,9 +19,7 @@ users.delete('/me', (_, res) => {
 })
 
 const statistics = Router()
-statistics.put('/', (_, res) => {
-  res.send('put statistics')
-})
+statistics.put('/', statisticsController.update)
 
 export const router = Router()
 router.use('/auth', auth)

--- a/apps/backend/controllers/statistics.ts
+++ b/apps/backend/controllers/statistics.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+import { handle } from '../lib/handle'
+import { validate } from '../lib/validate'
+import { prisma } from '../prisma/client'
+
+const update = handle(
+  async ({ req, res, userId }) => {
+    const { outcome } = validate(
+      req.body,
+      z.object({ outcome: z.enum(['win', 'loss', 'tie']) }),
+    )
+
+    const statistics = (await prisma.user.findUnique({
+      where: { id: userId },
+    }))!.statistics
+
+    let updates: typeof statistics
+    const updatedStreak = statistics.streak + 1
+
+    switch (outcome) {
+      case 'win':
+        updates = {
+          ...statistics,
+          wins: statistics.wins + 1,
+          streak: updatedStreak,
+          longestStreak:
+            updatedStreak > statistics.longestStreak
+              ? updatedStreak
+              : statistics.longestStreak,
+        }
+        break
+      case 'loss':
+        updates = {
+          ...statistics,
+          losses: statistics.losses + 1,
+          streak: 0,
+        }
+        break
+      case 'tie':
+        updates = {
+          ...statistics,
+          ties: statistics.ties + 1,
+          streak: 0,
+        }
+        break
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { statistics: updates },
+    })
+
+    res.status(200).json({ message: 'user statistics updated' })
+  },
+  { authenticate: true },
+)
+
+export const statistics = {
+  update,
+}

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ type Statistics {
   longestStreak Int @default(0)
   wins          Int @default(0)
   losses        Int @default(0)
+  ties          Int @default(0)
 }
 
 model RefreshToken {

--- a/apps/backend/yaak/yaak.rq_HNh4n4F8Cz.yaml
+++ b/apps/backend/yaak/yaak.rq_HNh4n4F8Cz.yaml
@@ -2,15 +2,23 @@ type: http_request
 model: http_request
 id: rq_HNh4n4F8Cz
 createdAt: 2025-05-20T13:12:55.709292
-updatedAt: 2025-05-26T12:50:16.250591
+updatedAt: 2025-06-02T07:29:50.072853
 workspaceId: wk_eovdddZRuv
 folderId: fl_Rw5LdepaS5
 authentication: {}
 authenticationType: null
-body: {}
-bodyType: null
+body:
+  text: |-
+    {
+      "outcome": "win"
+    }
+bodyType: application/json
 description: ''
-headers: []
+headers:
+- enabled: true
+  name: Content-Type
+  value: application/json
+  id: qX0AQr9hfE
 method: PUT
 name: /statistics
 sortPriority: 0.0


### PR DESCRIPTION
closes #28 

- create `PUT /statistics`
- updates the user statistics based on the `outcome`
- add `ties` to the statistics model