### PR TITLE
feat: `input` component

### DIFF
--- a/apps/frontend/src/components/Input.tsx
+++ b/apps/frontend/src/components/Input.tsx
@@ -1,0 +1,28 @@
+import type { InputHTMLAttributes } from 'react'
+import { cn } from '../utils/classname'
+
+export const Input = ({
+  label,
+  ...props
+}: { label: string } & InputHTMLAttributes<HTMLInputElement>) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="relative flex w-full items-center gap-2 rounded-lg border border-transparent bg-slate-600 px-4 py-2 text-slate-50 outline-none has-focus-visible:border-blue">
+        <input
+          {...props}
+          className="peer w-full outline-0 placeholder:text-transparent"
+        />
+        <label
+          htmlFor={props.id}
+          className={cn(
+            'absolute -top-4 left-2 cursor-text text-xs text-slate-300 transition-all',
+            'peer-focus-visible:-top-4 peer-focus-visible:left-2 peer-focus-visible:text-xs peer-focus-visible:text-blue',
+            'peer-placeholder-shown:top-2 peer-placeholder-shown:left-4 peer-placeholder-shown:text-base',
+          )}
+        >
+          {label}
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/Input.tsx
+++ b/apps/frontend/src/components/Input.tsx
@@ -3,11 +3,20 @@ import { cn } from '../utils/classname'
 
 export const Input = ({
   label,
+  error,
   ...props
-}: { label: string } & InputHTMLAttributes<HTMLInputElement>) => {
+}: {
+  label: string
+  error: string | null
+} & InputHTMLAttributes<HTMLInputElement>) => {
   return (
     <div className="flex flex-col gap-1">
-      <div className="relative flex w-full items-center gap-2 rounded-lg border border-transparent bg-slate-600 px-4 py-2 text-slate-50 outline-none has-focus-visible:border-blue">
+      <div
+        className={cn(
+          'relative flex w-full items-center gap-2 rounded-lg border border-transparent bg-slate-600 px-4 py-2 text-slate-50 outline-none has-focus-visible:border-blue',
+          error && 'border-red',
+        )}
+      >
         <input
           {...props}
           className="peer w-full outline-0 placeholder:text-transparent"
@@ -23,6 +32,7 @@ export const Input = ({
           {label}
         </label>
       </div>
+      {error && <span className="text-sm text-red">{error}</span>}
     </div>
   )
 }


### PR DESCRIPTION
Closes #40 
Created a cool inputfield component
To use you need:
* `placeholder` used for tracking focus on input field
* `id` for the built in `<label>`
* `label` is the default placeholder moving up and becoming the label when focused

Default:
![image](https://github.com/user-attachments/assets/000788b0-0d61-4605-aaef-62e9073b66aa)

Focus:
![image](https://github.com/user-attachments/assets/68474aba-9e24-47d1-a268-94ba196d8b0f)

Error:
![image](https://github.com/user-attachments/assets/28f5557e-ba24-41b9-b987-9d0317337a46)
