### PR TITLE
feat: refresh token interceptor

### DIFF
--- a/apps/frontend/src/lib/clients/backend.ts
+++ b/apps/frontend/src/lib/clients/backend.ts
@@ -1,7 +1,30 @@
 import axios from 'axios'
+import { refreshTokens } from '../requests'
 
 export const backend = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL,
   withCredentials: true,
   headers: { 'Content-Type': 'application/json' },
 })
+
+const authErrorCodes = [401, 403]
+
+backend.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const config = error.config
+
+    if (authErrorCodes.includes(error.response.status) && !config._retry) {
+      config._retry = true
+
+      try {
+        await refreshTokens()
+        return backend(config)
+      } catch (refreshError) {
+        return Promise.reject(refreshError)
+      }
+    }
+
+    return Promise.reject(error)
+  },
+)

--- a/apps/frontend/src/lib/requests.ts
+++ b/apps/frontend/src/lib/requests.ts
@@ -1,5 +1,16 @@
+import axios from 'axios'
 import type { User } from '../types/data'
 import { backend } from './clients/backend'
+
+export const refreshTokens = async () => {
+  // this needs to be it's own client to avoid an infinite loop with the interceptor
+  await axios
+    .create({
+      baseURL: import.meta.env.VITE_BACKEND_URL,
+      withCredentials: true,
+    })
+    .get('/auth/refresh-token')
+}
 
 export const getUser = async () => {
   try {


### PR DESCRIPTION
closes #124 

- create `refreshTokens` that requests the correct endpoint with a fresh client (otherwise it keeps intercepting itself and creates an infinite loop)
- create an axios interceptor that:
  - checks if the response failed with an auth error status code
  - tries to fetch new auth tokens using `refreshTokens`
  - retries the original request if new tokens could be fetched
  - throws other errors to be handled elsewhere