### PR TITLE
fix: split button positioning to be center

### DIFF
--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -47,7 +47,7 @@ export const GamePage = () => {
         <Button
           variant="blue"
           size="sm"
-          className="self-end md:absolute md:left-[calc(100%_+_0.75rem)]"
+          className="top-1/2 -translate-y-1/2 self-end md:absolute md:left-[calc(100%_+_0.75rem)]"
         >
           Split
         </Button>


### PR DESCRIPTION
Added button styling to center the button

Before:
![image](https://github.com/user-attachments/assets/f6c25a1a-8c5c-41ae-891f-b46ed9925e3f)


After:
![image](https://github.com/user-attachments/assets/cf46a991-2e1d-41ca-abbb-3a005dcba6e7)
