### PR TITLE
feat: create `GameMenu` modal

### DIFF
--- a/apps/frontend/src/components/modals/GameMenu.tsx
+++ b/apps/frontend/src/components/modals/GameMenu.tsx
@@ -1,0 +1,33 @@
+import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
+import { Link } from 'react-router'
+import { useModal } from '../../hooks/useModal'
+import { Button } from '../Button'
+import { Face } from '../Face'
+import { Logo } from '../Logo'
+import { Wrapper } from './Wrapper'
+
+export const GameMenu = () => {
+  const { close } = useModal()
+
+  return (
+    <Wrapper type="game-menu" classname="flex items-center flex-col gap-8">
+      <DialogTitle className="sr-only">Game menu</DialogTitle>
+      <DialogDescription className="sr-only">
+        Take an action or continue playing
+      </DialogDescription>
+
+      <div className="flex items-center gap-4">
+        <Logo text />
+        <Face suit="heart" value="jack" />
+      </div>
+      <nav className="flex w-full flex-col gap-3">
+        <Button onClick={close} variant="blue">
+          Continue playing
+        </Button>
+        <Button as={Link} to="/">
+          Quit
+        </Button>
+      </nav>
+    </Wrapper>
+  )
+}

--- a/apps/frontend/src/components/modals/Modals.tsx
+++ b/apps/frontend/src/components/modals/Modals.tsx
@@ -1,3 +1,9 @@
+import { GameMenu } from './GameMenu'
+
 export const Modals = () => {
-  return <></>
+  return (
+    <>
+      <GameMenu />
+    </>
+  )
 }

--- a/apps/frontend/src/components/modals/Wrapper.tsx
+++ b/apps/frontend/src/components/modals/Wrapper.tsx
@@ -1,13 +1,16 @@
 import * as Primitive from '@radix-ui/react-dialog'
 import { type ReactNode } from 'react'
 import { useModal, type ModalType } from '../../hooks/useModal'
+import { cn } from '../../utils/classname'
 
 export const Wrapper = ({
   children,
   type,
+  classname,
 }: {
   children: ReactNode
   type: ModalType
+  classname?: string
 }) => {
   const { isOpen, close } = useModal()
 
@@ -15,7 +18,12 @@ export const Wrapper = ({
     <Primitive.Root open={isOpen(type)} onOpenChange={close}>
       <Primitive.Portal>
         <Primitive.Overlay className="fixed inset-0 z-40 bg-slate-700/80 backdrop-blur-sm" />
-        <Primitive.Content className="fixed top-1/2 left-1/2 z-50 w-full max-w-sm -translate-1/2">
+        <Primitive.Content
+          className={cn(
+            'fixed top-1/2 left-1/2 z-50 max-w-sm -translate-1/2',
+            classname,
+          )}
+        >
           {children}
         </Primitive.Content>
       </Primitive.Portal>

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -6,15 +6,19 @@ import { Count } from '../components/Count'
 import { Header } from '../components/Header'
 import { Statistic } from '../components/Statistic'
 import { useGame } from '../hooks/useGame'
+import { useModal } from '../hooks/useModal'
 import { cn } from '../utils/classname'
 
 export const GamePage = () => {
   const { player, dealer } = useGame()
+  const { open } = useModal()
 
   return (
     <>
       <Header>
-        <Button size="sm">Menu</Button>
+        <Button onClick={() => open('game-menu')} size="sm">
+          Menu
+        </Button>
         <Statistic illustration="fire" value="3" />
       </Header>
 


### PR DESCRIPTION
closes #111

- create `GameMenu`
- open the modal when clicking the menu button in `GamePage`
- add `classname` to `Wrapper`