### PR TITLE
refactor: create `GameContext`

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -1,9 +1,14 @@
-import { useEffect, useState } from 'react'
+import { createContext, use, useEffect, useState, type ReactNode } from 'react'
 import { drawInitialCards } from '../lib/requests'
 // import type { Deck } from '../types/data'
 import type { Participant } from '../types/utils'
 
-export const useGame = () => {
+const GameContext = createContext<{
+  dealer: Participant | null
+  player: Participant | null
+} | null>(null)
+
+export const GameProvider = ({ children }: { children: ReactNode }) => {
   // const [deck, setDeck] = useState<Omit<Deck, 'cards'> | null>(null)
   const [dealer, setDealer] = useState<Participant | null>(null)
   const [player, setPlayer] = useState<Participant | null>(null)
@@ -25,5 +30,23 @@ export const useGame = () => {
     getCards()
   }, [])
 
-  return { player, dealer }
+  return (
+    <GameContext.Provider
+      value={{
+        dealer,
+        player,
+      }}
+    >
+      {children}
+    </GameContext.Provider>
+  )
+}
+
+export const useGame = () => {
+  const context = use(GameContext)
+  if (!context) {
+    throw new Error('useGame must be used within a GameProvider')
+  }
+
+  return context
 }

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router'
 import { Protected } from './components/Protected'
 import { AuthProvider } from './hooks/useAuth'
+import { GameProvider } from './hooks/useGame'
 import { Layout } from './layout'
 import { AuthenticatePage } from './pages/Authenticate'
 import { EditProfilePage } from './pages/EditProfile'
@@ -31,7 +32,9 @@ export const router = createBrowserRouter([
         path: '/game',
         element: (
           <Protected>
-            <GamePage />
+            <GameProvider>
+              <GamePage />
+            </GameProvider>
           </Protected>
         ),
       },


### PR DESCRIPTION
### what
- create `GameContext` to keep track of the game state
- create `GameProvider`
  - the logic from `useGame` was moved into here
- make `useGame` consume and distribute the context with error handling
- wrap `GamePage` in `GameProvider`

### why
this ensures we can use `useGame` in multiple child components inside of `GamePage` without fetching a new game  every time. it will make it much easier to break `GamePage` into smaller parts for readability and separation of concern