### PR TITLE
refactor: make sure game data always is available in `useGame`

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -4,8 +4,8 @@ import { drawInitialCards } from '../lib/requests'
 import type { Participant } from '../types/utils'
 
 const GameContext = createContext<{
-  dealer: Participant | null
-  player: Participant | null
+  dealer: Participant
+  player: Participant
 } | null>(null)
 
 export const GameProvider = ({ children }: { children: ReactNode }) => {
@@ -13,22 +13,30 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const [dealer, setDealer] = useState<Participant | null>(null)
   const [player, setPlayer] = useState<Participant | null>(null)
 
+  const [loading, setLoading] = useState(true)
+  const isLoading = loading || !player || !dealer
+
   useEffect(() => {
-    const getCards = async () => {
-      const { success, data, error } = await drawInitialCards()
+    drawInitialCards()
+      .then(({ success, data, error }) => {
+        if (!success) {
+          // TODO: create error boundry
+          throw new Error(error)
+        }
 
-      if (!success) {
-        // TODO: handle error
-        console.log(error)
-        return
-      }
-
-      // setDeck(data.deck)
-      setPlayer(data.player)
-      setDealer(data.dealer)
-    }
-    getCards()
+        // setDeck(data.deck)
+        setPlayer(data.player)
+        setDealer(data.dealer)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
   }, [])
+
+  if (isLoading) {
+    // TODO: create loading screen
+    return null
+  }
 
   return (
     <GameContext.Provider

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -26,7 +26,7 @@ export const GamePage = () => {
         <div className="flex grow flex-col items-center justify-between pt-[12vh] md:pt-8">
           <section className="flex flex-col items-center gap-4">
             <div className="flex gap-3">
-              {dealer?.cards.map(({ id, open, suit, value }) => {
+              {dealer.cards.map(({ id, open, suit, value }) => {
                 if (open) {
                   return (
                     <CardFront key={id} suit={suit} value={value} size="sm" />
@@ -40,7 +40,7 @@ export const GamePage = () => {
             <Count value="10" />
           </section>
           <section className="relative grid grid-cols-[min-content_4rem_min-content] pb-6 md:pb-0">
-            {player?.cards.map(({ id, suit, value }, index) => (
+            {player.cards.map(({ id, suit, value }, index) => (
               <CardFront
                 key={id}
                 suit={suit}


### PR DESCRIPTION
### what
make `player` and `dealer` always be non-nullable when accessed in `useGame`

### how
- rethrow the error if there is one
  - this will need to be handled with an [error boundary](https://react.dev/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary) right now it's just showing a blank screen
- return null if the cards are still loading
  - here we should show a loading screen instead
- if there's no error and the cards have finished loading we know for sure that the data is there

### why
this will make the data a lot simpler and more predictable to work with in `GamePage`