### PR TITLE
fix: `CardFront` `Face` size

### DIFF
--- a/apps/frontend/src/components/CardFront.tsx
+++ b/apps/frontend/src/components/CardFront.tsx
@@ -166,7 +166,7 @@ const Art = ({ suit, value, size }: Card & { size: Size }) => {
 
   if (isNaN(number)) {
     const classname = cn(
-      size === 'md' && 'w-16 md:w-full',
+      size === 'md' && 'w-16 md:w-20',
       size === 'sm' && 'w-14 md:w-18',
     )
 


### PR DESCRIPTION
closes #135 

![image](https://github.com/user-attachments/assets/07112be8-450a-4a6e-93a9-b30d17397e19)