### PR TITLE
refactor: delete `Modals`

### DIFF
--- a/apps/frontend/src/components/modals/Modals.tsx
+++ b/apps/frontend/src/components/modals/Modals.tsx
@@ -1,9 +1,0 @@
-import { GameMenu } from './GameMenu'
-
-export const Modals = () => {
-  return (
-    <>
-      <GameMenu />
-    </>
-  )
-}

--- a/apps/frontend/src/hooks/useModal.tsx
+++ b/apps/frontend/src/hooks/useModal.tsx
@@ -1,6 +1,5 @@
 import { createContext, use, useEffect, useState, type ReactNode } from 'react'
 import { useLocation } from 'react-router'
-import { Modals } from '../components/modals/Modals'
 
 export type ModalType = 'game-menu' | 'game-over'
 
@@ -35,7 +34,6 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
       }}
     >
       {children}
-      <Modals />
     </ModalContext.Provider>
   )
 }

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -4,6 +4,7 @@ import { CardBack } from '../components/CardBack'
 import { CardFront } from '../components/CardFront'
 import { Count } from '../components/Count'
 import { Header } from '../components/Header'
+import { GameMenu } from '../components/modals/GameMenu'
 import { Statistic } from '../components/Statistic'
 import { useAuth } from '../hooks/useAuth'
 import { useGame } from '../hooks/useGame'
@@ -92,6 +93,8 @@ export const GamePage = () => {
           </div>
         </nav>
       </main>
+
+      <GameMenu />
     </>
   )
 }


### PR DESCRIPTION
### what
delete `Modals` and move the modal directly to the game page

### why
the game over modal will need to access both the user and the winner so it needs to be within both of these providers so i thought it made more sense to move them here where they are used