### PR TITLE
feat: game over modal

### DIFF
--- a/apps/frontend/src/components/StatisticCard.tsx
+++ b/apps/frontend/src/components/StatisticCard.tsx
@@ -11,7 +11,7 @@ export const StatisticCard = ({
   value: string
 }) => {
   return (
-    <div className="flex flex-col gap-2 rounded-xl bg-slate-600 p-3">
+    <div className="flex flex-1 flex-col gap-2 rounded-xl bg-slate-600 p-3">
       <p className="font-bold">{name}</p>
       <Statistic illustration={illustration} value={value} />
     </div>

--- a/apps/frontend/src/components/modals/GameOver.tsx
+++ b/apps/frontend/src/components/modals/GameOver.tsx
@@ -1,0 +1,70 @@
+import { DialogDescription, DialogTitle } from '@radix-ui/react-dialog'
+import { Link } from 'react-router'
+import { useAuth } from '../../hooks/useAuth'
+import { useGame } from '../../hooks/useGame'
+import type { Winner } from '../../types/utils'
+import { Button } from '../Button'
+import { StatisticCard } from '../StatisticCard'
+import { Wrapper } from './Wrapper'
+
+const getTitle = (winner: Winner) => {
+  if (!winner) return 'Game over'
+
+  switch (winner) {
+    case 'dealer':
+      return 'You lost...'
+    case 'player':
+      return 'You won!'
+    case 'tie':
+      return 'You tied with the dealer.'
+  }
+}
+
+export const GameOver = () => {
+  const { winner } = useGame()
+  const { user } = useAuth()
+
+  return (
+    <Wrapper type="game-over" classname="w-full flex flex-col px-4 sm:p-0">
+      <DialogTitle className="text-center text-2xl font-black">
+        {getTitle(winner)}
+      </DialogTitle>
+      <DialogDescription className="sr-only">
+        Play again or quit to the main menu
+      </DialogDescription>
+
+      <div className="mt-6 flex gap-6">
+        <StatisticCard
+          name="Streak"
+          illustration="fire"
+          value={String(user.statistics.streak)}
+        />
+        <StatisticCard
+          name="Wins"
+          illustration="crown"
+          value={String(user.statistics.wins)}
+        />
+        <StatisticCard
+          name="Losses"
+          illustration="cloud"
+          value={String(user.statistics.losses)}
+        />
+      </div>
+
+      <div className="mt-8 flex w-full gap-3">
+        <Button
+          onClick={() => {
+            // TODO: reset game
+          }}
+          variant="blue"
+          className="flex-1"
+        >
+          Play again
+        </Button>
+        <Button as={Link} to="/">
+          Quit
+        </Button>
+      </div>
+    </Wrapper>
+  )
+}

--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -1,9 +1,7 @@
 import { createContext, use, useEffect, useState, type ReactNode } from 'react'
 import { drawInitialCards } from '../lib/requests'
 // import type { Deck } from '../types/data'
-import type { Participant } from '../types/utils'
-
-type Winner = 'dealer' | 'player' | 'tie' | null
+import type { Participant, Winner } from '../types/utils'
 
 const GameContext = createContext<{
   dealer: Participant

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -5,6 +5,7 @@ import { CardFront } from '../components/CardFront'
 import { Count } from '../components/Count'
 import { Header } from '../components/Header'
 import { GameMenu } from '../components/modals/GameMenu'
+import { GameOver } from '../components/modals/GameOver'
 import { Statistic } from '../components/Statistic'
 import { useAuth } from '../hooks/useAuth'
 import { useGame } from '../hooks/useGame'
@@ -96,6 +97,7 @@ export const GamePage = () => {
       </main>
 
       <GameMenu />
+      <GameOver />
     </>
   )
 }

--- a/apps/frontend/src/pages/Profile.tsx
+++ b/apps/frontend/src/pages/Profile.tsx
@@ -23,7 +23,7 @@ export const ProfilePage = () => {
             </Button>
           </div>
         </div>
-        <div className="flex flex-col gap-2 md:flex-row md:gap-6 md:*:flex-1">
+        <div className="flex flex-col gap-2 md:flex-row md:gap-6">
           <StatisticCard
             name="Longest streak"
             illustration="fire"

--- a/apps/frontend/src/types/utils.ts
+++ b/apps/frontend/src/types/utils.ts
@@ -12,6 +12,7 @@ export type Participant = {
     hard: number
   }
 }
+export type Winner = 'dealer' | 'player' | 'tie' | null
 
 export type Face = 'jack' | 'queen' | 'king'
 export type Illustration = 'fire' | 'crown' | 'cloud'


### PR DESCRIPTION
closes #65 

- create `GameOver` modal
  - dynamic title depending on the outcome of the game
  - shows the user stats
  - button to go back to the main menu
  - button to reset the game (functionality to be implemented)
- render the modal in `GamePage`