### PR TITLE
feat: dealer draw

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
-import { createContext, use, useState, type ReactNode } from 'react'
+import { createContext, use, useEffect, useState, type ReactNode } from 'react'
 import { draw, drawInitialCards } from '../lib/requests'
-import { calculateScore, getHighestValidScore } from '../lib/score'
+import { calculateScore, getWinner } from '../lib/score'
 import type { Deck } from '../types/data'
-// import type { Deck } from '../types/data'
 import type { Participant, Winner } from '../types/utils'
+import { sleep } from '../utils/sleep'
 import { useModal } from './useModal'
 
 const GameContext = createContext<{
@@ -22,6 +22,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const [dealer, setDealer] = useState<Participant | null>(null)
   const [player, setPlayer] = useState<Participant | null>(null)
   const [winner, setWinner] = useState<Winner>(null)
+  const [turn, setTurn] = useState<'player' | 'dealer' | 'over'>('player')
 
   const { isPending } = useQuery({
     queryKey: ['initial-cards'],
@@ -38,59 +39,48 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     throwOnError: true,
   })
 
+  useEffect(() => {
+    if (!dealer || !player || !deck) return
+
+    if (turn === 'dealer') {
+      const run = async () => {
+        let cards = dealer.cards.map((card) => ({ ...card, open: true }))
+        let score = calculateScore(cards)
+
+        setDealer({ cards, score })
+        await sleep()
+
+        while (score.soft < 17 || (score.soft > 21 && score.hard < 17)) {
+          const { deck: updatedDeck, card } = await draw(deck.deck_id)
+          setDeck(updatedDeck)
+
+          cards = [...cards, card]
+          score = calculateScore(cards)
+
+          await sleep()
+          setDealer({ cards, score: score })
+        }
+
+        await sleep(1000)
+        setTurn('over')
+      }
+      run()
+    }
+
+    if (turn === 'over') {
+      const winner = getWinner(dealer.score, player.score)
+      setWinner(winner)
+      open('game-over')
+    }
+  }, [turn])
+
   if (isPending || !dealer || !player || !deck) {
     // TODO: create loading screen
     return null
   }
 
-  const roundOver = (winner: NonNullable<Winner>) => {
-    setWinner(winner)
-    open('game-over')
-  }
-
-  const decideWinner = () => {
-    const playerScore = getHighestValidScore(player.score)
-    const dealerScore = getHighestValidScore(dealer.score)
-
-    if (!playerScore) {
-      return roundOver('dealer')
-    }
-
-    if (!dealerScore) {
-      return roundOver('player')
-    }
-
-    if (playerScore > dealerScore) {
-      return roundOver('player')
-    }
-
-    if (dealerScore > playerScore) {
-      return roundOver('dealer')
-    }
-
-    roundOver('tie')
-  }
-
-  const revealDealerCard = () => {
-    const cards = dealer.cards.map((card) => ({ ...card, open: true }))
-    setDealer({ ...dealer, cards })
-  }
-
-  const runDealerAction = () => {
-    const score = dealer.score
-
-    if (score.soft < 17) {
-      // TODO: draw new card for the dealer
-    } else if (score.hard > 21) {
-      roundOver('player')
-    } else {
-      decideWinner()
-    }
-  }
-
-  const stand = () => {
-    revealDealerCard()
-    runDealerAction()
+  const stand = async () => {
+    setTurn('dealer')
   }
 
   const hit = async () => {

--- a/apps/frontend/src/lib/score.ts
+++ b/apps/frontend/src/lib/score.ts
@@ -1,4 +1,4 @@
-import type { Participant } from '../types/utils'
+import type { Participant, Winner } from '../types/utils'
 
 export const calculateScore = (cards: Participant['cards']) => {
   let hard = 0
@@ -22,16 +22,42 @@ export const calculateScore = (cards: Participant['cards']) => {
   return { hard, soft }
 }
 
-export const getHighestValidScore = (score: Participant['score']) => {
-  if (score.soft < 21) {
+const getHighestValidScore = (score: Participant['score']) => {
+  if (score.soft <= 21) {
     return score.soft
   }
 
-  if (score.hard < 21) {
+  if (score.hard <= 21) {
     return score.hard
   }
 
   return null
+}
+
+export const getWinner = (
+  dealerScore: Participant['score'],
+  playerScore: Participant['score'],
+): NonNullable<Winner> => {
+  const highestDealerScore = getHighestValidScore(dealerScore)
+  const highestPlayerScore = getHighestValidScore(playerScore)
+
+  if (!highestPlayerScore) {
+    return 'dealer'
+  }
+
+  if (!highestDealerScore) {
+    return 'player'
+  }
+
+  if (highestPlayerScore > highestDealerScore) {
+    return 'player'
+  }
+
+  if (highestDealerScore > highestPlayerScore) {
+    return 'dealer'
+  }
+
+  return 'tie'
 }
 
 export const displayScore = (score: Participant['score']) => {

--- a/apps/frontend/src/utils/sleep.ts
+++ b/apps/frontend/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export const sleep = async (duration: number = 300) => {
+  await new Promise((resolve) => setTimeout(resolve, duration))
+}


### PR DESCRIPTION
- move dealer logic to a `useEffect` that does different things based on the new turn state
- draw new cards for the dealer until it has 17
- move `getWinner` to `score.ts`