### PR TITLE
fix: authenticate redirect

### DIFF
--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -9,6 +9,13 @@ const AuthContext = createContext<{ user: User; logOut: () => void } | null>(
   null,
 )
 
+export const useUser = () => {
+  return useQuery({
+    queryKey: ['user'],
+    queryFn: getUser,
+  })
+}
+
 export const AuthProvider = ({
   children,
   check,
@@ -19,10 +26,7 @@ export const AuthProvider = ({
   const navigate = useNavigate()
   const toast = useToast()
 
-  const { data: user, isPending } = useQuery({
-    queryKey: ['user'],
-    queryFn: getUser,
-  })
+  const { data: user, isPending } = useUser()
 
   if (isPending) {
     // TODO: create a loading screen

--- a/apps/frontend/src/pages/Authenticate.tsx
+++ b/apps/frontend/src/pages/Authenticate.tsx
@@ -1,10 +1,16 @@
-import { Link, useSearchParams } from 'react-router'
+import { Link, Navigate, useSearchParams } from 'react-router'
 import { Button } from '../components/Button'
 import { Logo } from '../components/Logo'
+import { useUser } from '../hooks/useAuth'
 
 export const AuthenticatePage = () => {
+  const { data: user } = useUser()
   const [searchParams] = useSearchParams()
   const error = searchParams.get('error')
+
+  if (user) {
+    return <Navigate to="/" />
+  }
 
   return (
     <main className="flex grow flex-col items-center justify-center gap-6">

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -56,17 +56,7 @@ export const router = createBrowserRouter([
       },
       {
         path: '/authenticate',
-        element: (
-          <AuthProvider
-            check={(user) => {
-              if (user) {
-                return '/'
-              }
-            }}
-          >
-            <AuthenticatePage />
-          </AuthProvider>
-        ),
+        element: <AuthenticatePage />,
       },
       {
         path: '/personalize-account',


### PR DESCRIPTION
there was an issue where you were redirected from the authenticate even if you were not logged in. meaning you couldn't log in at all. this fixes that by removing `AuthProvider` from `Authenticate` and just getting the user with `useUser`