### PR TITLE
fix: `Count` size

### DIFF
--- a/apps/frontend/src/components/Count.tsx
+++ b/apps/frontend/src/components/Count.tsx
@@ -10,7 +10,7 @@ export const Count = ({
   return (
     <span
       className={cn(
-        'flex w-16 justify-center rounded-full bg-slate-900 px-2 py-0.5 font-bold',
+        'flex w-18 justify-center rounded-full bg-slate-900 px-2 py-0.5 font-bold whitespace-nowrap',
         classname,
       )}
     >


### PR DESCRIPTION
closes #163 

### before
<img width="322" alt="image" src="https://github.com/user-attachments/assets/f445a278-13be-4e15-8ea7-86afa4052b8a" />

### after
<img width="284" alt="image" src="https://github.com/user-attachments/assets/1d7f65a1-1fb8-4151-9c60-775db36ce56a" />
