### PR TITLE
feat: update user statistics on game over

### DIFF
--- a/apps/frontend/src/components/Toaster.tsx
+++ b/apps/frontend/src/components/Toaster.tsx
@@ -32,7 +32,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
         {toasts.map((toast) => (
           <Toast {...toast} key={toast.id} />
         ))}
-        <Primitive.Viewport className="fixed top-12 right-4 left-4 flex flex-col gap-2 md:top-auto md:right-8 md:bottom-6 md:left-auto" />
+        <Primitive.Viewport className="fixed top-12 right-4 left-4 z-50 flex flex-col gap-2 md:top-auto md:right-8 md:bottom-6 md:left-auto" />
       </Primitive.Provider>
     </ToastContext.Provider>
   )

--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -1,7 +1,7 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { createContext, use, useEffect, useState, type ReactNode } from 'react'
-import { useToast } from '../components/Toaster'
-import { draw, drawInitialCards, updateStatistics } from '../lib/requests'
+import { useUpdateStatisticsMutation } from '../lib/mutations'
+import { draw, drawInitialCards } from '../lib/requests'
 import { calculateScore, getWinner, has21, outcomeMap } from '../lib/score'
 import type { Deck } from '../types/data'
 import type { Participant, Winner } from '../types/utils'
@@ -19,7 +19,6 @@ const GameContext = createContext<{
 
 export const GameProvider = ({ children }: { children: ReactNode }) => {
   const { open } = useModal()
-  const toast = useToast()
 
   const [deck, setDeck] = useState<Omit<Deck, 'cards'> | null>(null)
   const [dealer, setDealer] = useState<Participant | null>(null)
@@ -49,10 +48,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     throwOnError: true,
   })
 
-  const { mutate: handleOutcome } = useMutation({
-    mutationFn: updateStatistics,
-    onError: (error) => toast.error(error.message),
-  })
+  const { mutate: handleOutcome } = useUpdateStatisticsMutation()
 
   useEffect(() => {
     if (!dealer || !player || !deck) return

--- a/apps/frontend/src/lib/mutations.ts
+++ b/apps/frontend/src/lib/mutations.ts
@@ -1,0 +1,56 @@
+import { useMutation } from '@tanstack/react-query'
+import { useToast } from '../components/Toaster'
+import { queryClient } from '../providers/QueryClientProvider'
+import type { User } from '../types/data'
+import { updateStatistics } from './requests'
+
+const key = ['user']
+
+export const useUpdateStatisticsMutation = () => {
+  const toast = useToast()
+
+  return useMutation({
+    mutationFn: updateStatistics,
+    onMutate: async (outcome) => {
+      await queryClient.cancelQueries({ queryKey: key })
+
+      const user = queryClient.getQueryData<User>(key)!
+
+      queryClient.setQueryData(key, (old: User) => {
+        let updates = {}
+
+        switch (outcome) {
+          case 'win':
+            updates = {
+              wins: old.statistics.wins + 1,
+              streak: old.statistics.streak + 1,
+            }
+            break
+          case 'loss':
+            updates = {
+              losses: old.statistics.losses + 1,
+              streak: 0,
+            }
+            break
+          case 'tie':
+            updates = {
+              ties: old.statistics.ties + 1,
+              streak: 0,
+            }
+            break
+        }
+
+        return { ...old, statistics: { ...old.statistics, ...updates } }
+      })
+
+      return { user }
+    },
+    onError: (error, _, context) => {
+      queryClient.setQueryData(key, context?.user)
+      toast.error(error.message)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key })
+    },
+  })
+}

--- a/apps/frontend/src/lib/requests.ts
+++ b/apps/frontend/src/lib/requests.ts
@@ -1,5 +1,6 @@
 import axios, { isAxiosError } from 'axios'
 import { deckSchema, type User } from '../types/data'
+import type { Outcome } from '../types/utils'
 import { backend } from './clients/backend'
 import { deckOfCards } from './clients/cards'
 import { calculateScore } from './score'
@@ -50,6 +51,10 @@ export const updateUsername = async (username: string): Promise<Response> => {
   } catch (error) {
     return handleError(error, 'Something went wrong when updating the username')
   }
+}
+
+export const updateStatistics = async (outcome: Outcome) => {
+  await backend.put('/statistics', { outcome })
 }
 
 const formatDeck = (response: unknown) => {

--- a/apps/frontend/src/lib/score.ts
+++ b/apps/frontend/src/lib/score.ts
@@ -1,4 +1,4 @@
-import type { Participant, Winner } from '../types/utils'
+import type { Outcome, Participant, Winner } from '../types/utils'
 
 export const calculateScore = (
   cards: Participant['cards'],
@@ -84,6 +84,12 @@ export const getWinner = (
   }
 
   return 'tie'
+}
+
+export const outcomeMap: Record<NonNullable<Winner>, Outcome> = {
+  dealer: 'loss',
+  player: 'win',
+  tie: 'tie',
 }
 
 export const displayScore = (score: Participant['score']) => {

--- a/apps/frontend/src/types/utils.ts
+++ b/apps/frontend/src/types/utils.ts
@@ -13,7 +13,9 @@ export type Participant = {
     cardLength: number
   }
 }
+
 export type Winner = 'dealer' | 'player' | 'tie' | null
+export type Outcome = 'win' | 'loss' | 'tie'
 
 export type Face = 'jack' | 'queen' | 'king'
 export type Illustration = 'fire' | 'crown' | 'cloud'


### PR DESCRIPTION
closes #66 

- update user statistics on game over
- create `updateStatistics` request
- create `useUpdateStatisticsMutation`
  - handles errors
  - handles optimistic updates and rolls back the changes in case there's an error
  - once the request is finished it refetches the actual new data from the backend, ensuring we're not relying on the optimistic update too much