### PR TITLE
feat: create loading screen for `GamePage`

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { createContext, use, useEffect, useState, type ReactNode } from 'react'
 import { draw, drawInitialCards } from '../lib/requests'
 import { calculateScore, getWinner, has21 } from '../lib/score'
@@ -25,27 +25,20 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const [winner, setWinner] = useState<Winner>(null)
   const [turn, setTurn] = useState<'player' | 'dealer' | 'over'>('player')
 
-  const start = async () => {
-    const { deck, dealer, player } = await drawInitialCards()
-
-    setDeck(deck)
-    setDealer(dealer)
-    setPlayer(player)
-
-    if (has21(player.score)) {
-      await sleep(1000)
-      setTurn('dealer')
-    }
-  }
-
-  const { isPending } = useQuery({
+  const { data, refetch } = useSuspenseQuery({
     queryKey: ['initial-cards'],
-    queryFn: async () => {
-      await start()
-      return { success: true } // a queryFn needs to return something but we won't use this
-    },
-    throwOnError: true,
+    queryFn: drawInitialCards,
   })
+
+  useEffect(() => {
+    setDeck(data.deck)
+    setDealer(data.dealer)
+    setPlayer(data.player)
+
+    if (has21(data.player.score)) {
+      sleep(1000).then(() => setTurn('dealer'))
+    }
+  }, [data])
 
   useEffect(() => {
     if (!dealer || !player || !deck) return
@@ -82,21 +75,16 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [turn])
 
-  if (isPending || !dealer || !player || !deck) {
-    // TODO: create loading screen
-    return null
-  }
-
   const stand = async () => {
     setTurn('dealer')
   }
 
   const hit = async () => {
-    const { deck: updatedDeck, card } = await draw(deck.deck_id)
+    const { deck: updatedDeck, card } = await draw(deck!.deck_id)
 
     setDeck(updatedDeck)
 
-    const cards = [...player.cards, card]
+    const cards = [...player!.cards, card]
     const score = calculateScore(cards)
     setPlayer({ cards, score })
 
@@ -117,8 +105,11 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     setPlayer(null)
     setWinner(null)
     setTurn('player')
-    await start()
+    await refetch()
   }
+
+  // this will never happen, it's just here to make typescript happy
+  if (!dealer || !player) return null
 
   return (
     <GameContext.Provider

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -1,4 +1,5 @@
 import { Plus, X } from 'lucide-react'
+import { Suspense } from 'react'
 import { Button } from '../components/Button'
 import { CardBack } from '../components/CardBack'
 import { CardFront } from '../components/CardFront'
@@ -6,9 +7,10 @@ import { Count } from '../components/Count'
 import { Header } from '../components/Header'
 import { GameMenu } from '../components/modals/GameMenu'
 import { GameOver } from '../components/modals/GameOver'
+import { Skeleton } from '../components/Skeleton'
 import { Statistic } from '../components/Statistic'
 import { useAuth } from '../hooks/useAuth'
-import { useGame } from '../hooks/useGame'
+import { GameProvider, useGame } from '../hooks/useGame'
 import { useModal } from '../hooks/useModal'
 import { displayScore } from '../lib/score'
 import { cn } from '../utils/classname'
@@ -17,15 +19,29 @@ export const GamePage = () => {
   return (
     <>
       <GameHeader />
-      <main className="flex w-full grow flex-col items-center px-4 pb-4 md:pb-8">
-        <div className="flex grow flex-col items-center justify-between pt-[12vh] md:pt-8">
-          <DealerHand />
-          <PlayerHand />
-        </div>
-        <Actions />
-      </main>
-      <GameMenu />
-      <GameOver />
+      <Suspense
+        fallback={
+          <main className="flex w-full grow flex-col items-center px-4 pb-4 md:pb-8">
+            <div className="flex grow flex-col items-center justify-between pt-[12vh] md:pt-8">
+              <DealerHandSkeleton />
+              <PlayerHandSkeleton />
+            </div>
+            <ActionsSkeleton />
+          </main>
+        }
+      >
+        <GameProvider>
+          <main className="flex w-full grow flex-col items-center px-4 pb-4 md:pb-8">
+            <div className="flex grow flex-col items-center justify-between pt-[12vh] md:pt-8">
+              <DealerHand />
+              <PlayerHand />
+            </div>
+            <Actions />
+          </main>
+          <GameMenu />
+          <GameOver />
+        </GameProvider>
+      </Suspense>
     </>
   )
 }
@@ -65,6 +81,14 @@ const DealerHand = () => {
     </section>
   )
 }
+const DealerHandSkeleton = () => {
+  return (
+    <div className="flex gap-3">
+      <Skeleton classname="w-28 aspect-[2/3] rounded-lg md:w-36 md:rounded-xl" />
+      <Skeleton classname="w-28 aspect-[2/3] rounded-lg md:w-36 md:rounded-xl" />
+    </div>
+  )
+}
 
 const PlayerHand = () => {
   const { player } = useGame()
@@ -101,6 +125,14 @@ const PlayerHand = () => {
     </section>
   )
 }
+const PlayerHandSkeleton = () => {
+  return (
+    <div className="grid grid-cols-[min-content_min-content] pb-6 md:pb-0">
+      <Skeleton classname="w-32 col-start-1 col-end-3 aspect-[2/3] rounded-lg md:w-40 md:rounded-xl row-1 -rotate-2" />
+      <Skeleton classname="w-32 col-start-2 col-end-4 aspect-[2/3] rounded-lg md:w-40 md:rounded-xl row-1 rotate-2" />
+    </div>
+  )
+}
 
 const Actions = () => {
   const { stand, hit } = useGame()
@@ -130,6 +162,28 @@ const Actions = () => {
           icon={X}
           className="flex-1 md:w-36"
         >
+          Stand
+        </Button>
+      </div>
+    </nav>
+  )
+}
+const ActionsSkeleton = () => {
+  return (
+    <nav className="flex w-full max-w-sm flex-col gap-3 md:absolute md:top-1/2 md:left-1/2 md:-translate-1/2">
+      <Button
+        size="sm"
+        className="top-1/2 -translate-y-1/2 self-end md:absolute md:left-[calc(100%_+_0.75rem)]"
+        disabled
+      >
+        Split
+      </Button>
+
+      <div className="flex gap-3">
+        <Button icon={Plus} className="flex-1 md:w-36" disabled>
+          Hit
+        </Button>
+        <Button icon={X} className="flex-1 md:w-36" disabled>
           Stand
         </Button>
       </div>

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -1,7 +1,6 @@
 import { createBrowserRouter } from 'react-router'
 import { Protected } from './components/Protected'
 import { AuthProvider } from './hooks/useAuth'
-import { GameProvider } from './hooks/useGame'
 import { Layout } from './layout'
 import { AuthenticatePage } from './pages/Authenticate'
 import { EditProfilePage } from './pages/EditProfile'
@@ -32,9 +31,7 @@ export const router = createBrowserRouter([
         path: '/game',
         element: (
           <Protected>
-            <GameProvider>
-              <GamePage />
-            </GameProvider>
+            <GamePage />
           </Protected>
         ),
       },


### PR DESCRIPTION
- create a loading screen for `GamePage` using `useSuspenseQuery` and a `Suspense` boundary
- i redid the initial fetch to use `useSuspenseQuery` instead of `useQuery` and update the states with a `useEffect` instead of the `start` function
- create skeletons for each part of the game that needs the game to load
- create a `Suspense` with a `fallback` that uses the skeletons

https://github.com/user-attachments/assets/8e3c297d-74ba-4fcb-b062-cc2f482b400a