### PR TITLE
fix: if soft is bust, only show hard

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -2,7 +2,14 @@ import { useQuery } from '@tanstack/react-query'
 import { createContext, use, useEffect, useState, type ReactNode } from 'react'
 import { useUpdateStatisticsMutation } from '../lib/mutations'
 import { draw, drawInitialCards } from '../lib/requests'
-import { calculateScore, getWinner, has21, outcomeMap } from '../lib/score'
+import {
+  calculateScore,
+  getWinner,
+  has21,
+  isHardBust,
+  isSoftBust,
+  outcomeMap,
+} from '../lib/score'
 import type { Deck } from '../types/data'
 import type { Participant, Winner } from '../types/utils'
 import { sleep } from '../utils/sleep'
@@ -61,7 +68,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
         setDealer({ cards, score })
         await sleep()
 
-        while (score.soft < 17 || (score.soft > 21 && score.hard < 17)) {
+        while (score.soft < 17 || (isSoftBust(score) && score.hard < 17)) {
           const { deck: updatedDeck, card } = await draw(deck.deck_id)
           setDeck(updatedDeck)
 
@@ -109,7 +116,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
       setTurn('dealer')
     }
 
-    if (score.hard > 21) {
+    if (isHardBust(score)) {
       await sleep(1000)
       setTurn('over')
     }

--- a/apps/frontend/src/lib/score.ts
+++ b/apps/frontend/src/lib/score.ts
@@ -52,6 +52,14 @@ export const hasBlackjack = (score: Participant['score']) => {
   return false
 }
 
+export const isSoftBust = (score: Participant['score']) => {
+  return score.soft > 21
+}
+
+export const isHardBust = (score: Participant['score']) => {
+  return score.hard > 21
+}
+
 export const getWinner = (
   dealerScore: Participant['score'],
   playerScore: Participant['score'],
@@ -93,7 +101,7 @@ export const outcomeMap: Record<NonNullable<Winner>, Outcome> = {
 }
 
 export const displayScore = (score: Participant['score']) => {
-  if (score.hard === score.soft) {
+  if (score.hard === score.soft || isSoftBust(score)) {
     return String(score.hard)
   }
 


### PR DESCRIPTION
close #183 

- create `isSoftBust` and `isHardBust`
- add `isSoftBust` check to `displayScore`

this would’ve said **26 / 16** before, now it only shows the hard score

<img width="461" alt="image" src="https://github.com/user-attachments/assets/6a45cef0-4883-4060-b24e-d2435f16b3a3" />