### PR TITLE
fix: reset game on modal dismiss

### DIFF
--- a/apps/frontend/src/components/modals/GameOver.tsx
+++ b/apps/frontend/src/components/modals/GameOver.tsx
@@ -27,7 +27,11 @@ export const GameOver = () => {
   const { user } = useAuth()
 
   return (
-    <Wrapper type="game-over" classname="w-full flex flex-col px-4 sm:p-0">
+    <Wrapper
+      type="game-over"
+      onDismiss={reset}
+      classname="w-full flex flex-col px-4 sm:p-0"
+    >
       <DialogTitle className="text-center text-2xl font-black">
         {getTitle(winner)}
       </DialogTitle>

--- a/apps/frontend/src/components/modals/Wrapper.tsx
+++ b/apps/frontend/src/components/modals/Wrapper.tsx
@@ -6,16 +6,24 @@ import { cn } from '../../utils/classname'
 export const Wrapper = ({
   children,
   type,
+  onDismiss,
   classname,
 }: {
   children: ReactNode
   type: ModalType
+  onDismiss?: () => void
   classname?: string
 }) => {
   const { isOpen, close } = useModal()
 
   return (
-    <Primitive.Root open={isOpen(type)} onOpenChange={close}>
+    <Primitive.Root
+      open={isOpen(type)}
+      onOpenChange={() => {
+        onDismiss?.()
+        close()
+      }}
+    >
       <Primitive.Portal>
         <Primitive.Overlay className="fixed inset-0 z-40 bg-slate-700/80 backdrop-blur-sm" />
         <Primitive.Content


### PR DESCRIPTION
closes #185 

- add optional `onDismiss` to `Wrapper`
- set `GameOver` modal `onDismiss` to `reset`