### PR TITLE
feat: multiple hands

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -1,5 +1,11 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createContext, use, useEffect, useState, type ReactNode } from 'react'
+import {
+  allHandsDone,
+  getPlayingHand,
+  updatePlayingHand,
+  updateWaitingHand,
+} from '../lib/hand'
 import { useUpdateStatisticsMutation } from '../lib/mutations'
 import { draw, drawInitialCards } from '../lib/requests'
 import {
@@ -10,14 +16,13 @@ import {
   isSoftBust,
   outcomeMap,
 } from '../lib/score'
-import type { Deck } from '../types/data'
-import type { Participant, Winner } from '../types/utils'
+import type { Dealer, Deck, Hand, Player, Winner } from '../types/utils'
 import { sleep } from '../utils/sleep'
 import { useModal } from './useModal'
 
 const GameContext = createContext<{
-  dealer: Participant
-  player: Participant
+  dealer: Dealer
+  player: Player
   winner: Winner
   actionsDisabled: boolean
   stand: () => void
@@ -28,9 +33,10 @@ const GameContext = createContext<{
 export const GameProvider = ({ children }: { children: ReactNode }) => {
   const { open } = useModal()
 
-  const [deck, setDeck] = useState<Omit<Deck, 'cards'> | null>(null)
-  const [dealer, setDealer] = useState<Participant | null>(null)
-  const [player, setPlayer] = useState<Participant | null>(null)
+  const [deck, setDeck] = useState<Deck | null>(null)
+  const [dealer, setDealer] = useState<Dealer | null>(null)
+  const [player, setPlayer] = useState<Player | null>(null)
+
   const [winner, setWinner] = useState<Winner>(null)
   const [turn, setTurn] = useState<'player' | 'dealer' | 'over'>('player')
   const [actionsDisabled, setActionsDisabled] = useState(false)
@@ -47,7 +53,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     setDealer(data.dealer)
     setPlayer(data.player)
 
-    if (has21(data.player.score)) {
+    if (has21(data.player.hands[0].score)) {
       setActionsDisabled(true)
       sleep(1000).then(() => setTurn('dealer'))
     }
@@ -85,33 +91,63 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     }
 
     if (turn === 'over') {
-      const winner = getWinner(dealer.score, player.score)
+      const winners = player.hands.map((hand) =>
+        getWinner(dealer.score, hand.score),
+      )
+      const playerWin = winners.some((winner) => winner === 'player')
+      const dealerWin = winners.every((winner) => winner === 'dealer')
+      const winner = playerWin ? 'player' : dealerWin ? 'dealer' : 'tie'
+
       setWinner(winner)
       handleOutcome(outcomeMap[winner])
       open('game-over')
     }
   }, [turn])
 
+  const next = async (hands: Hand[], status: 'stood' | 'bust' | '21') => {
+    await sleep(1000)
+
+    const updatedPlayingHand = updatePlayingHand(hands, { status: 'done' })
+    if (allHandsDone(updatedPlayingHand)) {
+      setPlayer({ ...player, hands: updatedPlayingHand })
+
+      switch (status) {
+        case 'bust':
+          return setTurn('over')
+        case 'stood':
+        case '21':
+          return setTurn('dealer')
+      }
+    }
+
+    const updatedWaitingHand = updateWaitingHand(updatedPlayingHand, {
+      status: 'playing',
+    })
+    setPlayer({ ...player, hands: updatedWaitingHand })
+  }
+
   const stand = async () => {
-    setTurn('dealer')
+    await next(player!.hands, 'stood')
   }
 
   const hit = async () => {
     const { deck: updatedDeck, card } = await draw(deck!.deck_id)
-
     setDeck(updatedDeck)
 
-    const cards = [...player!.cards, card]
+    const { hand } = getPlayingHand(player!.hands)
+
+    const cards = [...hand.cards, card]
     const score = calculateScore(cards)
-    setPlayer({ cards, score })
+    const hands = updatePlayingHand(player!.hands, { cards, score })
+
+    setPlayer({ ...player, hands })
 
     if (has21(score)) {
-      setTurn('dealer')
+      await next(hands, '21')
     }
 
     if (isHardBust(score)) {
-      await sleep(1000)
-      setTurn('over')
+      await next(hands, 'bust')
     }
   }
 

--- a/apps/frontend/src/lib/hand.ts
+++ b/apps/frontend/src/lib/hand.ts
@@ -1,0 +1,27 @@
+import type { Hand } from '../types/utils'
+
+export const getPlayingHand = (hands: Hand[]) => {
+  const condition = (hand: Hand) => hand.status === 'playing'
+
+  return {
+    hand: hands.find(condition)!,
+    index: hands.findIndex(condition),
+  }
+}
+
+export const updatePlayingHand = (hands: Hand[], updates: Partial<Hand>) => {
+  return hands.map((hand) =>
+    hand.status === 'playing' ? { ...hand, ...updates } : hand,
+  )
+}
+
+export const updateWaitingHand = (hands: Hand[], updates: Partial<Hand>) => {
+  const { index: playingIndex } = getPlayingHand(hands)
+  return hands.map((hand, index) =>
+    index === playingIndex + 1 ? { ...hand, ...updates } : hand,
+  )
+}
+
+export const allHandsDone = (hands: Hand[]) => {
+  return hands.every(({ status }) => status === 'done')
+}

--- a/apps/frontend/src/lib/requests.ts
+++ b/apps/frontend/src/lib/requests.ts
@@ -1,6 +1,6 @@
 import axios, { isAxiosError } from 'axios'
 import { deckSchema, type User } from '../types/data'
-import type { Outcome } from '../types/utils'
+import type { Dealer, Deck, Outcome, Player } from '../types/utils'
 import { backend } from './clients/backend'
 import { deckOfCards } from './clients/cards'
 import { calculateScore } from './score'
@@ -75,7 +75,11 @@ const formatDeck = (response: unknown) => {
   return { cards, deck }
 }
 
-export const drawInitialCards = async () => {
+export const drawInitialCards = async (): Promise<{
+  deck: Deck
+  dealer: Dealer
+  player: Player
+}> => {
   const response = await deckOfCards.get('/new/draw', {
     params: {
       count: '4',
@@ -90,8 +94,17 @@ export const drawInitialCards = async () => {
 
   return {
     deck,
-    player: { cards: playerCards, score: calculateScore(playerCards) },
     dealer: { cards: dealerCards, score: calculateScore(dealerCards) },
+    player: {
+      hands: [
+        {
+          id: crypto.randomUUID(),
+          cards: playerCards,
+          score: calculateScore(playerCards),
+          status: 'playing',
+        },
+      ],
+    },
   }
 }
 

--- a/apps/frontend/src/lib/score.ts
+++ b/apps/frontend/src/lib/score.ts
@@ -1,8 +1,6 @@
-import type { Outcome, Participant, Winner } from '../types/utils'
+import type { Hand, Outcome, Winner } from '../types/utils'
 
-export const calculateScore = (
-  cards: Participant['cards'],
-): Participant['score'] => {
+export const calculateScore = (cards: Hand['cards']): Hand['score'] => {
   let hard = 0
   let soft = 0
 
@@ -24,7 +22,7 @@ export const calculateScore = (
   return { hard, soft, cardLength: cards.length }
 }
 
-const getHighestValidScore = (score: Participant['score']) => {
+const getHighestValidScore = (score: Hand['score']) => {
   if (score.soft <= 21) {
     return score.soft
   }
@@ -36,7 +34,7 @@ const getHighestValidScore = (score: Participant['score']) => {
   return null
 }
 
-export const has21 = (score: Participant['score']) => {
+export const has21 = (score: Hand['score']) => {
   if (score.soft === 21 || score.hard === 21) {
     return true
   }
@@ -44,7 +42,7 @@ export const has21 = (score: Participant['score']) => {
   return false
 }
 
-export const hasBlackjack = (score: Participant['score']) => {
+export const hasBlackjack = (score: Hand['score']) => {
   if (has21(score) && score.cardLength === 2) {
     return true
   }
@@ -52,17 +50,17 @@ export const hasBlackjack = (score: Participant['score']) => {
   return false
 }
 
-export const isSoftBust = (score: Participant['score']) => {
+export const isSoftBust = (score: Hand['score']) => {
   return score.soft > 21
 }
 
-export const isHardBust = (score: Participant['score']) => {
+export const isHardBust = (score: Hand['score']) => {
   return score.hard > 21
 }
 
 export const getWinner = (
-  dealerScore: Participant['score'],
-  playerScore: Participant['score'],
+  dealerScore: Hand['score'],
+  playerScore: Hand['score'],
 ): NonNullable<Winner> => {
   const highestDealerScore = getHighestValidScore(dealerScore)
   const highestPlayerScore = getHighestValidScore(playerScore)
@@ -100,7 +98,7 @@ export const outcomeMap: Record<NonNullable<Winner>, Outcome> = {
   tie: 'tie',
 }
 
-export const displayScore = (score: Participant['score']) => {
+export const displayScore = (score: Hand['score']) => {
   if (score.hard === score.soft || isSoftBust(score)) {
     return String(score.hard)
   }

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -24,7 +24,7 @@ export const GamePage = () => {
           <main className="flex w-full grow flex-col items-center px-4 pb-4 md:pb-8">
             <div className="flex grow flex-col items-center justify-between pt-[12vh] md:pt-8">
               <DealerHandSkeleton />
-              <PlayerHandSkeleton />
+              <PlayerHandsSkeleton />
             </div>
             <ActionsSkeleton />
           </main>
@@ -34,7 +34,7 @@ export const GamePage = () => {
           <main className="flex w-full grow flex-col items-center px-4 pb-4 md:pb-8">
             <div className="flex grow flex-col items-center justify-between pt-[12vh] md:pt-8">
               <DealerHand />
-              <PlayerHand />
+              <PlayerHands />
             </div>
             <Actions />
           </main>
@@ -90,42 +90,47 @@ const DealerHandSkeleton = () => {
   )
 }
 
-const PlayerHand = () => {
+const PlayerHands = () => {
   const { player } = useGame()
 
   return (
-    <section
-      style={{
-        gridTemplateColumns: Array(player.cards.length)
-          .fill('min-content')
-          .join(' '),
-      }}
-      className="relative grid pb-6 md:pb-0"
-    >
-      {player.cards.map(({ id, suit, value }, index) => (
-        <CardFront
+    <section>
+      {player.hands.map(({ id, cards, score }) => (
+        <div
           key={id}
-          suit={suit}
-          value={value}
           style={{
-            gridColumn: `${index + 1} / ${index + 3}`,
+            gridTemplateColumns: Array(cards.length)
+              .fill('min-content')
+              .join(' '),
           }}
-          classname={cn(
-            'row-1',
-            index % 2 === 0 && '-rotate-2',
-            index % 2 === 1 && 'rotate-2',
-          )}
-          size="md"
-        />
+          className="relative grid pb-6 md:pb-0"
+        >
+          {cards.map(({ id, suit, value }, index) => (
+            <CardFront
+              key={id}
+              suit={suit}
+              value={value}
+              style={{
+                gridColumn: `${index + 1} / ${index + 3}`,
+              }}
+              classname={cn(
+                'row-1',
+                index % 2 === 0 && '-rotate-2',
+                index % 2 === 1 && 'rotate-2',
+              )}
+              size="md"
+            />
+          ))}
+          <Count
+            value={displayScore(score)}
+            classname="absolute top-4 left-[calc(100%_-_2rem)]"
+          />
+        </div>
       ))}
-      <Count
-        value={displayScore(player.score)}
-        classname="absolute top-4 left-[calc(100%_-_2rem)]"
-      />
     </section>
   )
 }
-const PlayerHandSkeleton = () => {
+const PlayerHandsSkeleton = () => {
   return (
     <div className="grid grid-cols-[min-content_min-content] pb-6 md:pb-0">
       <Skeleton classname="w-32 col-start-1 col-end-3 aspect-[2/3] rounded-lg md:w-40 md:rounded-xl row-1 -rotate-2" />

--- a/apps/frontend/src/types/data.ts
+++ b/apps/frontend/src/types/data.ts
@@ -56,11 +56,9 @@ export const cardSchema = z.object({
   suit: z.enum(suits).transform((suit) => suitMap[suit]),
   value: z.enum(values).transform((value) => valueMap[value]),
 })
-export type Card = z.infer<typeof cardSchema>
 
 export const deckSchema = z.object({
   deck_id: z.string(),
   remaining: z.number(),
   cards: z.array(cardSchema),
 })
-export type Deck = z.infer<typeof deckSchema>

--- a/apps/frontend/src/types/utils.ts
+++ b/apps/frontend/src/types/utils.ts
@@ -1,17 +1,30 @@
 import type { ComponentPropsWithoutRef, ElementType } from 'react'
-import type { Card } from './data'
+import type { z } from 'zod'
+import type { cardSchema, deckSchema } from './data'
 
 export type Number = '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10'
 export type Value = Number | 'J' | 'Q' | 'K' | 'A'
 export type Suit = 'heart' | 'diamond' | 'club' | 'spade'
 
-export type Participant = {
-  cards: (Card & { id: string; open: boolean })[]
-  score: {
-    soft: number
-    hard: number
-    cardLength: number
-  }
+export type Deck = Omit<z.infer<typeof deckSchema>, 'cards'>
+type Card = z.infer<typeof cardSchema> & { id: string; open: boolean }
+type Score = {
+  soft: number
+  hard: number
+  cardLength: number
+}
+
+type Status = 'waiting' | 'playing' | 'done'
+export type Hand = {
+  id: string
+  cards: Card[]
+  score: Score
+  status: Status
+}
+
+export type Dealer = Omit<Hand, 'id' | 'status'>
+export type Player = {
+  hands: Hand[]
 }
 
 export type Winner = 'dealer' | 'player' | 'tie' | null


### PR DESCRIPTION
part of #68 

add support for multiple player hands

### types
- `Participant` has been split into two separate types, one for `Dealer` and one for `Player`
  - a `Player` now has multiple hands and a `status` for each hand

### data fetching
- `drawInitialCards` has been updated to follow the new `Player` format

### hand utils
- create `hand.ts` with helper functions for dealing with player hands
- `getPlayingHand` gets the currently active hand, and `updatePlayingHand` can be used to update/patch it
- `updateWaitingHand` can be used to update the next hand in line
- `allHandsDone` checks if all hands has the status `done` and then it's the dealers turn

### game logic
- create `next` function that updates the `status` for the current hand and sets the next waiting hand to `playing`
- update the winner logic to include multiple hands
  - if the player has won at least one hand they are considered the winner
  - if the dealer won all hands they are considered the winner
  - else it's a tie

### game ui
- atm i just changed it to loop out the one hand, i'll handle the styling when creating the split functionality