### PR TITLE
feat: split

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -25,6 +25,7 @@ const GameContext = createContext<{
   player: Player
   winner: Winner
   actionsDisabled: boolean
+  canSplit: boolean
   stand: () => void
   hit: () => void
   reset: () => Promise<void>
@@ -37,8 +38,9 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const [dealer, setDealer] = useState<Dealer | null>(null)
   const [player, setPlayer] = useState<Player | null>(null)
 
-  const [winner, setWinner] = useState<Winner>(null)
+  const [canSplit, setCanSplit] = useState(false)
   const [turn, setTurn] = useState<'player' | 'dealer' | 'over'>('player')
+  const [winner, setWinner] = useState<Winner>(null)
   const [actionsDisabled, setActionsDisabled] = useState(false)
 
   const { data, refetch } = useSuspenseQuery({
@@ -54,7 +56,10 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     setDealer(data.dealer)
     setPlayer(data.player)
 
-    if (has21(data.player.hands[0].score)) {
+    const firstHand = data.player.hands[0]
+    setCanSplit(firstHand.cards[0].value === firstHand.cards[1].value)
+
+    if (has21(firstHand.score)) {
       setActionsDisabled(true)
       sleep(1000).then(() => setTurn('dealer'))
     }
@@ -171,6 +176,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
         dealer,
         player,
         winner,
+        canSplit,
         actionsDisabled,
         stand,
         hit,

--- a/apps/frontend/src/lib/hand.ts
+++ b/apps/frontend/src/lib/hand.ts
@@ -1,4 +1,23 @@
-import type { Hand } from '../types/utils'
+import type { Card, Hand, Status } from '../types/utils'
+import { calculateScore } from './score'
+
+export const createHand = ({
+  cards,
+  base,
+  status,
+}: {
+  cards: Card[]
+  base?: Hand
+  status?: Status
+}): Hand => {
+  return {
+    ...(base || {}),
+    id: base?.id || crypto.randomUUID(),
+    cards,
+    score: calculateScore(cards),
+    status: status || base?.status || 'waiting',
+  }
+}
 
 export const getPlayingHand = (hands: Hand[]) => {
   const condition = (hand: Hand) => hand.status === 'playing'
@@ -9,6 +28,33 @@ export const getPlayingHand = (hands: Hand[]) => {
   }
 }
 
+export const addCardToHand = ({
+  hand,
+  card,
+}: {
+  hand: Hand
+  card: Card
+}): Hand => {
+  const cards = [...hand.cards, card]
+  return {
+    ...hand,
+    cards,
+    score: calculateScore(cards),
+  }
+}
+
+export const updateHandById = ({
+  hands,
+  id,
+  updates,
+}: {
+  hands: Hand[]
+  id: string
+  updates: Partial<Hand>
+}) => {
+  return hands.map((hand) => (hand.id === id ? { ...hand, ...updates } : hand))
+}
+
 export const updatePlayingHand = (hands: Hand[], updates: Partial<Hand>) => {
   return hands.map((hand) =>
     hand.status === 'playing' ? { ...hand, ...updates } : hand,
@@ -16,9 +62,9 @@ export const updatePlayingHand = (hands: Hand[], updates: Partial<Hand>) => {
 }
 
 export const updateWaitingHand = (hands: Hand[], updates: Partial<Hand>) => {
-  const { index: playingIndex } = getPlayingHand(hands)
+  const waitingIndex = hands.findIndex(({ status }) => status === 'waiting')
   return hands.map((hand, index) =>
-    index === playingIndex + 1 ? { ...hand, ...updates } : hand,
+    index === waitingIndex ? { ...hand, ...updates } : hand,
   )
 }
 

--- a/apps/frontend/src/lib/requests.ts
+++ b/apps/frontend/src/lib/requests.ts
@@ -3,6 +3,7 @@ import { deckSchema, type User } from '../types/data'
 import type { Dealer, Deck, Outcome, Player } from '../types/utils'
 import { backend } from './clients/backend'
 import { deckOfCards } from './clients/cards'
+import { createHand } from './hand'
 import { calculateScore } from './score'
 
 type Response =
@@ -96,27 +97,20 @@ export const drawInitialCards = async (): Promise<{
     deck,
     dealer: { cards: dealerCards, score: calculateScore(dealerCards) },
     player: {
-      hands: [
-        {
-          id: crypto.randomUUID(),
-          cards: playerCards,
-          score: calculateScore(playerCards),
-          status: 'playing',
-        },
-      ],
+      hands: [createHand({ cards: playerCards, status: 'playing' })],
     },
   }
 }
 
-export const draw = async (deckId: string) => {
+export const draw = async (deckId: string, count: number = 1) => {
   const response = await deckOfCards.get(`/${deckId}/draw`, {
-    params: { count: '1' },
+    params: { count },
   })
   const { deck, cards } = formatDeck(response.data)
 
   return {
     deck,
-    card: cards[0],
+    cards,
   }
 }
 

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -94,8 +94,8 @@ const PlayerHands = () => {
   const { player } = useGame()
 
   return (
-    <section>
-      {player.hands.map(({ id, cards, score }) => (
+    <section className="flex items-end gap-16">
+      {[...player.hands].reverse().map(({ id, cards, score, status }) => (
         <div
           key={id}
           style={{
@@ -103,7 +103,11 @@ const PlayerHands = () => {
               .fill('min-content')
               .join(' '),
           }}
-          className="relative grid pb-6 md:pb-0"
+          className={cn(
+            'relative grid pb-6 md:pb-0',
+            player.hands.length > 1 && status === 'playing' && 'mb-4',
+            player.hands.length > 1 && status !== 'playing' && 'opacity-50',
+          )}
         >
           {cards.map(({ id, suit, value }, index) => (
             <CardFront
@@ -140,11 +144,12 @@ const PlayerHandsSkeleton = () => {
 }
 
 const Actions = () => {
-  const { stand, hit, canSplit, actionsDisabled } = useGame()
+  const { stand, hit, split, canSplit, actionsDisabled } = useGame()
 
   return (
     <nav className="flex w-full max-w-sm flex-col gap-3 md:absolute md:top-1/2 md:left-1/2 md:-translate-1/2">
       <Button
+        onClick={split}
         disabled={!canSplit || actionsDisabled}
         variant="blue"
         size="sm"

--- a/apps/frontend/src/pages/Game.tsx
+++ b/apps/frontend/src/pages/Game.tsx
@@ -140,12 +140,12 @@ const PlayerHandsSkeleton = () => {
 }
 
 const Actions = () => {
-  const { stand, hit, actionsDisabled } = useGame()
+  const { stand, hit, canSplit, actionsDisabled } = useGame()
 
   return (
     <nav className="flex w-full max-w-sm flex-col gap-3 md:absolute md:top-1/2 md:left-1/2 md:-translate-1/2">
       <Button
-        disabled={actionsDisabled}
+        disabled={!canSplit || actionsDisabled}
         variant="blue"
         size="sm"
         className="top-1/2 -translate-y-1/2 self-end md:absolute md:left-[calc(100%_+_0.75rem)]"

--- a/apps/frontend/src/types/utils.ts
+++ b/apps/frontend/src/types/utils.ts
@@ -7,14 +7,14 @@ export type Value = Number | 'J' | 'Q' | 'K' | 'A'
 export type Suit = 'heart' | 'diamond' | 'club' | 'spade'
 
 export type Deck = Omit<z.infer<typeof deckSchema>, 'cards'>
-type Card = z.infer<typeof cardSchema> & { id: string; open: boolean }
+export type Card = z.infer<typeof cardSchema> & { id: string; open: boolean }
 type Score = {
   soft: number
   hard: number
   cardLength: number
 }
 
-type Status = 'waiting' | 'playing' | 'done'
+export type Status = 'waiting' | 'playing' | 'done'
 export type Hand = {
   id: string
   cards: Card[]


### PR DESCRIPTION
closes #68 

### new hand helpers
  - `createHand` for creating a new hand. either a completely new, or one based on a previous hand
  - `addCardToHand` for adding a new card to an existing hand
  - `updateHandById` for updating a hand by its id
  - also fixed `updateWaitingHand` because the index calculation was wrong

### data fetching
- update `draw` to dynamically take the count of cards to draw

### game logic
- create `canSplit` state
  - it is set to true if the initial draw has two cards of equal value
  - it is then set back to false once you click split
- create `split` function
  - first it splits the initial hand in two and updates the ui
  - then it draws a card for the first hand and updates the ui
  - then it draws a second card for the second hand and updates the ui

### game ui
- add styling for the layout
- add styling based on the status of the hand

https://github.com/user-attachments/assets/71c4fe81-c7af-4159-aa87-6d62529441ad