### PR TITLE
feat: shuffle deck feature

### DIFF
--- a/apps/frontend/src/hooks/useGame.tsx
+++ b/apps/frontend/src/hooks/useGame.tsx
@@ -35,6 +35,8 @@ const GameContext = createContext<{
   reset: () => Promise<void>
 } | null>(null)
 
+const fullDeckSize = 52 * 6
+
 export const GameProvider = ({ children }: { children: ReactNode }) => {
   const { open } = useModal()
 
@@ -46,10 +48,12 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const [turn, setTurn] = useState<'player' | 'dealer' | 'over'>('player')
   const [winner, setWinner] = useState<Winner>(null)
   const [actionsDisabled, setActionsDisabled] = useState(false)
+  const shuffle = !deck || deck.remaining <= fullDeckSize / 3
 
   const { data, refetch } = useSuspenseQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: ['initial-cards'],
-    queryFn: drawInitialCards,
+    queryFn: async () => drawInitialCards(shuffle ? undefined : deck.deck_id),
     refetchOnWindowFocus: false,
   })
 

--- a/apps/frontend/src/lib/requests.ts
+++ b/apps/frontend/src/lib/requests.ts
@@ -83,9 +83,15 @@ export const drawInitialCards = async (
   dealer: Dealer
   player: Player
 }> => {
-  const response = await deckOfCards.get(`/${deckId}/draw`, {
-    params: { count: '4' },
-  })
+  const response = await deckOfCards.get(
+    deckId ? `/${deckId}/draw` : '/new/draw',
+    {
+      params: {
+        count: '4',
+        deck_count: deckId ? null : '6',
+      },
+    },
+  )
 
   const { deck, cards } = formatDeck(response.data)
 

--- a/apps/frontend/src/lib/requests.ts
+++ b/apps/frontend/src/lib/requests.ts
@@ -76,16 +76,15 @@ const formatDeck = (response: unknown) => {
   return { cards, deck }
 }
 
-export const drawInitialCards = async (): Promise<{
+export const drawInitialCards = async (
+  deckId?: string,
+): Promise<{
   deck: Deck
   dealer: Dealer
   player: Player
 }> => {
-  const response = await deckOfCards.get('/new/draw', {
-    params: {
-      count: '4',
-      deck_count: '6',
-    },
+  const response = await deckOfCards.get(`/${deckId}/draw`, {
+    params: { count: '4' },
   })
 
   const { deck, cards } = formatDeck(response.data)


### PR DESCRIPTION
closes #159 
does not actually shuffle the deck, it just checks the remaining cards in the playing deck. once its only 1/3 left (~208 cards). Once its bellow said number, will fetch a new deck from api and the game will start over again